### PR TITLE
Host type check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.6.5] - 2020-07-12
+### Changed:
+- Added a `host_name` option to prevent accidentally database purges on non-master hosts.
+- Updated `monolog` library to v2.x.
+
 ## [0.6.4] - 2020-03-02
 ### Changed:
 - Added a `JiraTicketNotFound` exception to better analyse deleted/or missing jira tickets. Which resultet in database or folder to be ignored instead of removed. [#24](https://github.com/icanhazstring/duck-pony/pull/24) (thanks to [@d-feller](https://github.com/d-feller))
@@ -32,7 +37,7 @@ pdo installed [#23](https://github.com/icanhazstring/duck-pony/pull/23) (thanks 
 
 ### Removed:
 - Removed support of `--config|c` option on certain commands as the configs is created using `tempa-php`
-- Removed `symfony/yaml` as a dependency 
+- Removed `symfony/yaml` as a dependency
 
 ## [0.5.1] - 2019-11-19
 ### Fixed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
 ## [0.6.5] - 2020-07-12
-### Changed:
+### Added:
 - Added a `host_name` option to prevent accidentally database purges on non-master hosts.
+### Changed:
 - Updated `monolog` library to v2.x.
 
 ## [0.6.4] - 2020-03-02

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -18,6 +18,7 @@
          slack_token=SLACK_TOKEN \
          slack_channel=SLACK_CHANNEL
      ```
+- add the `host_name` option to `purge:database` and `db:clean` with the master's hostname to prevent accidentally dropping databases on slaves
 
 ## 0.3 to 0.4
 Adjust config.yml:

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "icanhazstring/duck-pony",
-    "type": "project",
+    "type": "library",
     "description": "Secret Duck Pony",
     "license": "MIT",
     "authors": [
@@ -17,7 +17,7 @@
         "symfony/console": "^4.0",
         "symfony/filesystem": "^4.0",
         "symfony/finder": "^4.0",
-        "monolog/monolog": "^1.25",
+        "monolog/monolog": "^2.0",
         "league/container": "^3.3",
         "zendframework/zend-config": "^3.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     ],
     "require": {
         "php": "^7.2",
+        "ext-pdo": "*",
         "icanhazstring/systemctl-php": "^0.7",
         "icanhazstring/tempa-php": "^2.0",
         "lesstif/php-jira-rest-client": "^1.10",
@@ -22,7 +23,6 @@
         "zendframework/zend-config": "^3.3"
     },
     "require-dev": {
-        "ext-pdo": "*",
         "ext-openssl": "*",
         "roave/security-advisories": "dev-master",
         "squizlabs/php_codesniffer": "^3.5",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
     ],
     "require": {
         "php": "^7.2",
-        "ext-pdo": "*",
         "icanhazstring/systemctl-php": "^0.7",
         "icanhazstring/tempa-php": "^2.0",
         "lesstif/php-jira-rest-client": "^1.10",
@@ -23,6 +22,7 @@
         "zendframework/zend-config": "^3.3"
     },
     "require-dev": {
+        "ext-pdo": "*",
         "ext-openssl": "*",
         "roave/security-advisories": "dev-master",
         "squizlabs/php_codesniffer": "^3.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "749280c6671cdc217272a6ced362742c",
+    "content-hash": "5e443816b1bcc40425443552a3c4e4ba",
     "packages": [
         {
             "name": "icanhazstring/systemctl-php",
@@ -223,21 +223,21 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "1.25.3",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "fa82921994db851a8becaf3787a9e73c5976b6f1"
+                "reference": "38914429aac460e8e4616c8cb486ecb40ec90bb1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/fa82921994db851a8becaf3787a9e73c5976b6f1",
-                "reference": "fa82921994db851a8becaf3787a9e73c5976b6f1",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/38914429aac460e8e4616c8cb486ecb40ec90bb1",
+                "reference": "38914429aac460e8e4616c8cb486ecb40ec90bb1",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0",
-                "psr/log": "~1.0"
+                "php": ">=7.2",
+                "psr/log": "^1.0.1"
             },
             "provide": {
                 "psr/log-implementation": "1.0.0"
@@ -245,33 +245,36 @@
             "require-dev": {
                 "aws/aws-sdk-php": "^2.4.9 || ^3.0",
                 "doctrine/couchdb": "~1.0@dev",
-                "graylog2/gelf-php": "~1.0",
-                "jakub-onderka/php-parallel-lint": "0.9",
+                "elasticsearch/elasticsearch": "^6.0",
+                "graylog2/gelf-php": "^1.4.2",
                 "php-amqplib/php-amqplib": "~2.4",
                 "php-console/php-console": "^3.1.3",
-                "phpunit/phpunit": "~4.5",
-                "phpunit/phpunit-mock-objects": "2.3.0",
+                "php-parallel-lint/php-parallel-lint": "^1.0",
+                "phpspec/prophecy": "^1.6.1",
+                "phpunit/phpunit": "^8.5",
+                "predis/predis": "^1.1",
+                "rollbar/rollbar": "^1.3",
                 "ruflin/elastica": ">=0.90 <3.0",
-                "sentry/sentry": "^0.13",
                 "swiftmailer/swiftmailer": "^5.3|^6.0"
             },
             "suggest": {
                 "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
                 "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
                 "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
-                "ext-mongo": "Allow sending log messages to a MongoDB server",
+                "ext-mbstring": "Allow to work properly with unicode symbols",
+                "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
                 "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
-                "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
                 "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
                 "php-console/php-console": "Allow sending log messages to Google Chrome",
                 "rollbar/rollbar": "Allow sending log messages to Rollbar",
-                "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
-                "sentry/sentry": "Allow sending log messages to a Sentry server"
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "2.x-dev"
                 }
             },
             "autoload": {
@@ -297,7 +300,17 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2019-12-20T14:15:16+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-22T08:12:19+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
@@ -3703,5 +3716,6 @@
     "platform-dev": {
         "ext-pdo": "*",
         "ext-openssl": "*"
-    }
+    },
+    "plugin-api-version": "1.1.0"
 }

--- a/src/Console/Command/Option/HostNameOptionTrait.php
+++ b/src/Console/Command/Option/HostNameOptionTrait.php
@@ -17,7 +17,7 @@ trait HostNameOptionTrait
 
     protected function configureHostNameOption(): void
     {
-        $this->addOption('host_name', 'hn', InputOption::VALUE_OPTIONAL, 'The hostname of the master host machine');
+        $this->addOption('host_name', 'h', InputOption::VALUE_REQUIRED, 'The hostname of the master host machine');
     }
 
     protected function getHostName(InputInterface $input): ?string

--- a/src/Console/Command/Option/HostNameOptionTrait.php
+++ b/src/Console/Command/Option/HostNameOptionTrait.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace duckpony\Console\Command\Option;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * @uses \Zend\Config\Config
+ * @author Dogan Ucar <dogan@dogan-ucar.de>
+ */
+trait HostNameOptionTrait
+{
+
+    protected function configureHostNameOption(): void
+    {
+        $this->addOption('host_name', 'hn', InputOption::VALUE_OPTIONAL, 'The hostname of the master host machine');
+    }
+
+    protected function getHostName(InputInterface $input): ?string
+    {
+        return $input->getOption('host_name') ?? null;
+    }
+
+    protected function canRunOnHost(?string $hostNameFromOptions, SymfonyStyle $io): bool
+    {
+        $hostName = gethostname();
+        $hostName = $hostName === false ? null : $hostName;
+
+        if ($hostName === null) {
+            $io->warning('No hostname. Please configure so that gethostname() returns a value. The command will run!');
+            return true;
+        }
+
+        if ($hostNameFromOptions === null) {
+            $io->note('No configurations regarding to master/slave found. The command will run regularly on any host!');
+            return true;
+        }
+
+        return $hostNameFromOptions === $hostName;
+    }
+}

--- a/src/Console/Command/PurgeIssueDatabaseCommand.php
+++ b/src/Console/Command/PurgeIssueDatabaseCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace duckpony\Console\Command;
 
 use duckpony\Console\Command\Argument\BranchnameFilterArgumentTrait;
+use duckpony\Console\Command\Option\HostNameOptionTrait;
 use duckpony\Console\Command\Option\PatternOptionTrait;
 use duckpony\Console\Command\Option\StatusOptionTrait;
 use duckpony\Exception\JiraTicketNotFoundException;
@@ -30,6 +31,7 @@ class PurgeIssueDatabaseCommand extends Command
     use BranchnameFilterArgumentTrait;
     use StatusOptionTrait;
     use PatternOptionTrait;
+    use HostNameOptionTrait;
 
     protected const DEPRECATION_ALIAS = 'db:clean';
 
@@ -75,6 +77,7 @@ class PurgeIssueDatabaseCommand extends Command
         $this->configureStatusOption();
         $this->configureBranchnameFilterArgument();
         $this->configurePatternOption();
+        $this->configureHostNameOption();
 
         $this->addOption('invert', 'i', InputOption::VALUE_NONE, 'Invert status');
 
@@ -97,7 +100,14 @@ EOT
 
         $invert = $this->getInvert($input);
         $pattern = $this->getPattern($input);
+        $hostName = $this->getHostName($input);
         $branchNameFilter = $this->getBranchnameFilter($input);
+        $canRunOnHost = $this->canRunOnHost($hostName, $io);
+
+        if ($canRunOnHost === false) {
+            $io->note('You are running this command on master and have configured to stop if so. Please make sure you are on master or configure the host_name option.');
+            die(0);
+        }
 
         if (!isset($this->config->username, $this->config->password, $this->config->hostname)) {
             throw new RuntimeException('MySQL config is incorrect! Username, password and hostname required!');

--- a/src/Console/Command/PurgeIssueDatabaseCommand.php
+++ b/src/Console/Command/PurgeIssueDatabaseCommand.php
@@ -105,7 +105,8 @@ EOT
         $canRunOnHost = $this->canRunOnHost($hostName, $io);
 
         if ($canRunOnHost === false) {
-            $io->note('You are running this command on master and have configured to stop if so. Please make sure you are on master or configure the host_name option.');
+            $io->note('You are running this command on master and have configured to stop if so.' .
+                ' Please make sure you are on master or configure the host_name option.');
             die(0);
         }
 

--- a/test/Unit/Rule/IsIssueWithGivenStatusRuleTest.php
+++ b/test/Unit/Rule/IsIssueWithGivenStatusRuleTest.php
@@ -6,6 +6,7 @@ use duckpony\Exception\JiraTicketNotFoundException;
 use duckpony\Rule\IsIssueWithGivenStatusRule;
 use JiraRestApi\Issue\Issue;
 use JiraRestApi\Issue\IssueField;
+use JiraRestApi\Issue\IssueStatus;
 use PHPUnit\Framework\TestCase;
 
 class IsIssueWithGivenStatusRuleTest extends TestCase
@@ -14,7 +15,12 @@ class IsIssueWithGivenStatusRuleTest extends TestCase
     {
 
         $issue = new Issue();
-        $issue->fields->status->name = 'test1';
+        $status = new IssueStatus();
+        $status->name = 'test1';
+        $field = new IssueField();
+        $field->status = $status;
+        $issue->fields = $field;
+
         return [
             'it should return true given an issue with status included in statuses and not inverted' => [
                 'given' => [


### PR DESCRIPTION
This PR should introduce a new option `host_name` to duck-pony.

Given an infrastructure you are hosting a master and X slave machines. Duck-pony should not drop databases on slaves as it would result in serious issues with the database replication.

The proposed option is simple: When provided, it will check the option agains PHP's `gethostname()` method. If they are the same, the command runs as usual. If not, the command stops with a notice.

Affecting commands:

* PurgeDatabaseCommand
* PurgeIssueDatabaseCommand