### PR TITLE
Add Keep days option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+### Added:
+- Added the `keep-days` option to the `folder:clean` command to specify the maximum amount of days a branch is allowed to remain
+  - The branch will be deleted after the maximum amount of days, even if the issue status does not match
+
 ## [0.6.5] - 2020-07-12
 ### Added:
 - Added a `host_name` option to prevent accidentally database purges on non-master hosts.[#26](https://github.com/icanhazstring/duck-pony/pull/26) (thanks to [@doganoo](https://github.com/doganoo))

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ vendor/bin/tempa file:substitute \
     instance_pattern=SYSTEMD_SERVICE_PATTERN \
     slack_token=SLACK_TOKEN \
     slack_channel=SLACK_CHANNEL
-    
+
 ```
 
 > The `pattern` is used to identify tickets and folders alike. This means, your folders **MUST** have the same name
@@ -59,20 +59,21 @@ Arguments:
   branchname-filter      Remove parts of the folder name to match jira ticket
 
 Options:
-  -s, --status=STATUS    Status
-  -p, --pattern=PATTERN  Branch pattern
-  -i, --invert           Invert status
-  -y, --yes              Confirm questions with yes
-  -c, --config=CONFIG    Config [default: "/home/vendor/duck-pony/config/config.yml"]
-  -f, --force            Force delete
-  -h, --help             Display this help message
-  -q, --quiet            Do not output any message
-  -V, --version          Display this application version
-      --ansi             Force ANSI output
-      --no-ansi          Disable ANSI output
-  -n, --no-interaction   Do not ask any interactive question
-  -v|vv|vvv, --verbose   Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
-  --branchname-filter    Remove parts of the branchname for better jira ticket matching
+  -s, --status=STATUS          Status
+  -p, --pattern=PATTERN        Branch pattern
+      --keep-days[=KEEP-DAYS]  The number of days a branch is allowed to remain.
+  -i, --invert                 Invert status
+  -y, --yes                    Confirm questions with yes
+  -c, --config=CONFIG          Config [default: "/home/vendor/duck-pony/config/config.yml"]
+  -f, --force                  Force delete
+  -h, --help                   Display this help message
+  -q, --quiet                  Do not output any message
+  -V, --version                Display this application version
+      --ansi                   Force ANSI output
+      --no-ansi                Disable ANSI output
+  -n, --no-interaction         Do not ask any interactive question
+  -v|vv|vvv, --verbose         Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+  --branchname-filter          Remove parts of the branchname for better jira ticket matching
 
 Help:
   Scan folder iterate over sub folders and removes
@@ -117,8 +118,8 @@ Assuming the following folder structure and services:
 ```
 /path/to/folder
  |- ABC-123
- 
- 
+
+
 systemd services:
 - awesome@ABC-124
 - awesome@ABC-125
@@ -174,7 +175,7 @@ Usage:
   db:clean [options] [--] <pattern>
 
 Arguments:
-  branchname-filter      Remove parts of the folder name to match jira ticket                 
+  branchname-filter      Remove parts of the folder name to match jira ticket
 
 Options:
   -s, --status=STATUS    Status

--- a/src/Console/Command/Option/KeepDaysOptionTrait.php
+++ b/src/Console/Command/Option/KeepDaysOptionTrait.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace duckpony\Console\Command\Option;
+
+use InvalidArgumentException;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Style\StyleInterface;
+
+trait KeepDaysOptionTrait
+{
+    protected function configureKeepDaysOption(): void
+    {
+        $this->addOption(
+            'keep-days',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'The number of days a branch is allowed to remain.'
+        );
+    }
+
+    protected function getKeepDays(InputInterface $input): ?int
+    {
+        $keepDaysString = $input->getOption('keep-days');
+        if ($keepDaysString === null) {
+            return null;
+        }
+
+        if (!is_numeric($keepDaysString) || $keepDaysString <= 0) {
+            throw new InvalidArgumentException(
+                sprintf('Option "keep-days" must be an integer and bigger than 0, "%s" given.', $keepDaysString)
+            );
+        }
+
+        return (int) $keepDaysString;
+    }
+}

--- a/src/Console/Command/Option/KeepDaysOptionTrait.php
+++ b/src/Console/Command/Option/KeepDaysOptionTrait.php
@@ -7,7 +7,6 @@ namespace duckpony\Console\Command\Option;
 use InvalidArgumentException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Style\StyleInterface;
 
 trait KeepDaysOptionTrait
 {

--- a/src/Console/Command/PurgeIssueFolderCommand.php
+++ b/src/Console/Command/PurgeIssueFolderCommand.php
@@ -105,7 +105,7 @@ EOT
             $keepDays = $this->getKeepDays($input);
         } catch (InvalidArgumentException $e) {
             $io->error($e->getMessage());
-            die(1);
+            return 1;
         }
 
         $finder = new Finder();

--- a/src/Rule/IsDirectoryTooOld.php
+++ b/src/Rule/IsDirectoryTooOld.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace duckpony\Rule;

--- a/src/Rule/IsDirectoryTooOld.php
+++ b/src/Rule/IsDirectoryTooOld.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace duckpony\Rule;
+
+use SplFileInfo;
+
+final class IsDirectoryTooOld
+{
+    /**
+     * This Rule returns true if the given $dir was modified more than $keepDays days ago.
+     *
+     * @param SplFileInfo $dir
+     * @param int $keepDays
+     * @return bool
+     */
+    public function appliesTo(SplFileInfo $dir, int $keepDays): bool
+    {
+        $maxCreationTime = strtotime('-' . $keepDays . ' day', time());
+        return $dir->getMTime() < $maxCreationTime;
+    }
+}

--- a/test/Unit/Console/Command/Option/KeepDaysOptionTraitTest.php
+++ b/test/Unit/Console/Command/Option/KeepDaysOptionTraitTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace duckpony\Test\Unit\Console\Command\Option;
@@ -25,10 +26,12 @@ class KeepDaysOptionTraitTest extends TestCase
         $this->input = $input = new ArrayInput(
             [],
             new InputDefinition([
-                new InputOption('keep-days',
+                new InputOption(
+                    'keep-days',
                     null,
                     InputOption::VALUE_OPTIONAL,
-                    'The number of days a branch is allowed to remain.')
+                    'The number of days a branch is allowed to remain.'
+                ),
             ])
         );
 

--- a/test/Unit/Console/Command/Option/KeepDaysOptionTraitTest.php
+++ b/test/Unit/Console/Command/Option/KeepDaysOptionTraitTest.php
@@ -1,0 +1,91 @@
+<?php
+declare(strict_types=1);
+
+namespace duckpony\Test\Unit\Console\Command\Option;
+
+use duckpony\Console\Command\Option\KeepDaysOptionTrait;
+use InvalidArgumentException;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+
+class KeepDaysOptionTraitTest extends TestCase
+{
+    /** @var InputInterface */
+    private $input;
+
+    /** @var KeepDaysOptionTrait */
+    private $subject;
+
+    protected function setUp(): void
+    {
+        $this->input = $input = new ArrayInput(
+            [],
+            new InputDefinition([
+                new InputOption('keep-days',
+                    null,
+                    InputOption::VALUE_OPTIONAL,
+                    'The number of days a branch is allowed to remain.')
+            ])
+        );
+
+        $this->subject = new class {
+            use KeepDaysOptionTrait {
+                getKeepDays as traitGetKeepDays;
+            }
+
+            public function getKeepDays(InputInterface $input): ?int
+            {
+                return $this->traitGetKeepDays($input);
+            }
+        };
+    }
+
+    public function provideValidKeepDaysOptionValues(): array
+    {
+        return [
+            ['1', 1],
+            ['2', 2],
+            [(string) PHP_INT_MAX, PHP_INT_MAX],
+            [1, 1],
+            [2, 2],
+            [PHP_INT_MAX, PHP_INT_MAX],
+            [null, null],
+        ];
+    }
+
+    /**
+     * @dataProvider provideValidKeepDaysOptionValues
+     */
+    public function testGetKeepDays($inputOptionValue, ?int $expectedOptionValue): void
+    {
+        $this->input->setOption('keep-days', $inputOptionValue);
+
+        $keepDays = $this->subject->getKeepDays($this->input);
+        Assert::assertSame($expectedOptionValue, $keepDays);
+    }
+
+    public function provideInvalidKeepDaysOptionValues(): array
+    {
+        return [
+            ['0', 'Option "keep-days" must be an integer and bigger than 0, "0" given.'],
+            ['-1', 'Option "keep-days" must be an integer and bigger than 0, "-1" given.'],
+            ['foo', 'Option "keep-days" must be an integer and bigger than 0, "foo" given.'],
+            ['true', 'Option "keep-days" must be an integer and bigger than 0, "true" given.'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideInvalidKeepDaysOptionValues
+     */
+    public function testGetKeepDaysWithInvalidValue(string $inputOptionValue, string $expectedExceptionMessage): void
+    {
+        $this->input->setOption('keep-days', $inputOptionValue);
+
+        $this->expectExceptionObject(new InvalidArgumentException($expectedExceptionMessage));
+        $this->subject->getKeepDays($this->input);
+    }
+}

--- a/test/Unit/Rule/IsDirectoryTooOldTest.php
+++ b/test/Unit/Rule/IsDirectoryTooOldTest.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+namespace duckpony\Test\Unit\Rule;
+
+use duckpony\Rule\IsDirectoryTooOld;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use SplFileInfo;
+
+final class IsDirectoryTooOldTest extends TestCase
+{
+    public function provideDirectories(): array
+    {
+        /** @var SplFileInfo|MockObject $file */
+        $file = $this->createMock(SplFileInfo::class);
+        $file->method('getMTime')->willReturn(strtotime('-2 day', time()));
+
+        return [
+            'not too old' => [
+                'dir' => $file,
+                'keepDays' => 2,
+                'expectedResult' => false,
+            ],
+            'too old' => [
+                'dir' => $file,
+                'keepDays' => 1,
+                'expectedResult' => true,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideDirectories
+     */
+    public function testAppliesTo(SplFileInfo $dir, int $keepDays, bool $expectedResult): void
+    {
+        $subject = new IsDirectoryTooOld();
+        $result = $subject->appliesTo($dir, $keepDays);
+        Assert::assertSame($expectedResult, $result);
+    }
+}

--- a/test/Unit/Rule/IsDirectoryTooOldTest.php
+++ b/test/Unit/Rule/IsDirectoryTooOldTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace duckpony\Test\Unit\Rule;
@@ -13,18 +14,18 @@ final class IsDirectoryTooOldTest extends TestCase
 {
     public function provideDirectories(): array
     {
-        /** @var SplFileInfo|MockObject $file */
-        $file = $this->createMock(SplFileInfo::class);
-        $file->method('getMTime')->willReturn(strtotime('-2 day', time()));
+        /** @var SplFileInfo|MockObject $dir */
+        $dir = $this->createMock(SplFileInfo::class);
+        $dir->method('getMTime')->willReturn(strtotime('-2 day', time()));
 
         return [
             'not too old' => [
-                'dir' => $file,
+                'dir' => $dir,
                 'keepDays' => 2,
                 'expectedResult' => false,
             ],
             'too old' => [
-                'dir' => $file,
+                'dir' => $dir,
                 'keepDays' => 1,
                 'expectedResult' => true,
             ],


### PR DESCRIPTION
The `--keep-days` option can be used to specify the maximum amount of days a branch is allowed to remain.
The branch will be deleted after the maximum amount of days, even if the issue status does not match.